### PR TITLE
Use the `cloud.r-project.org` mirror

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -96,7 +96,7 @@ get_download_url() {
   local version=$2
   local major_version
   major_version="$(echo "$version" | cut -d. -f1)"
-  echo "https://mirrors.nics.utk.edu/cran/src/base/R-${major_version}/R-${version}.tar.gz"
+  echo "https://cloud.r-project.org/src/base/R-${major_version}/R-${version}.tar.gz"
 }
 
 install_R "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
 
-function sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
-}
-
+# Get versions (only fully numeric versions) for each major release
 versions=""
-
 for major_version in {2..4}; do
-  versions="${versions} $(curl --silent "https://cloud.r-project.org/src/base/R-${major_version}/" | tr '<>' ',,' | awk -F, '/tar.gz/{ print $13 }' | sed -e 's/.tar.gz//g' -e 's/R-//')"
+  versions="${versions}
+$(curl -sL "https://cloud.r-project.org/src/base/R-${major_version}/" | grep -o '"R-[0-9]*.[0-9]*.[0-9]*.tar.gz"' | sed 's/"R-\(.*\).tar.gz"$/\1/')"
 done
 
-echo "$versions" | sort_versions | xargs echo
+# Sort versions and remove any blank lines
+echo "$versions" | LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n | sed '/^ *$/d'

--- a/bin/list-all
+++ b/bin/list-all
@@ -8,7 +8,7 @@ function sort_versions() {
 versions=""
 
 for major_version in {2..4}; do
-  versions="${versions} $(curl --silent "https://mirrors.nics.utk.edu/cran/src/base/R-${major_version}/" | tr '<>' ',,' | awk -F, '/tar.gz/{ print $13 }' | sed -e 's/.tar.gz//g' -e 's/R-//')"
+  versions="${versions} $(curl --silent "https://cloud.r-project.org/src/base/R-${major_version}/" | tr '<>' ',,' | awk -F, '/tar.gz/{ print $13 }' | sed -e 's/.tar.gz//g' -e 's/R-//')"
 done
 
 echo "$versions" | sort_versions | xargs echo

--- a/bin/list-all
+++ b/bin/list-all
@@ -8,4 +8,5 @@ $(curl -sL "https://cloud.r-project.org/src/base/R-${major_version}/" | grep -o 
 done
 
 # Sort versions and remove any blank lines
-echo "$versions" | LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n | sed '/^ *$/d'
+echo "$versions" | LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n |  sed ':a; N; $!ba; s/\n/ /g'
+


### PR DESCRIPTION
I recently had problems with connecting to the currently used CRAN mirror. This fixed the issue. The `cloud.r-project.org` mirror has "Automatic redirection to servers worldwide". As such it is likely to be more reliable, and performant, than any one CRAN mirror.