### PR TITLE
Updates the README to resolve #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ More details on environment variables setup for Mac OS builds can be found [here
 ## Install
 
 ```
-asdf plugin-add R https://github.com/asdf-community/asdf-r.git
+asdf plugin-add r https://github.com/asdf-community/asdf-r.git
 ```
 
 ## ASDF options


### PR DESCRIPTION
Based on #10 the issue is itself not actually with the install but the instructions provided to install the ASDF plugin for R.

This is just a single line change in the README to resolve the message `R is invalid. Name may only contain lowercase letters, numbers, '_', and '-'`:

```shell
asdf plugin-add r https://github.com/asdf-community/asdf-r.git
```